### PR TITLE
chore: use existing tokensVersion

### DIFF
--- a/ui/src/app/tokens/Tokens.tsx
+++ b/ui/src/app/tokens/Tokens.tsx
@@ -132,7 +132,7 @@ export default function Tokens() {
           setOpen={setShowDeleteTokenModal}
           handleDelete={() =>
             deleteTokens(deletingTokens?.map((t) => t.id) || []).then(() => {
-              dispatchEvent(new CustomEvent('token-deleted'));
+              incrementTokensVersion();
             })
           }
           onSuccess={() => {
@@ -178,6 +178,7 @@ export default function Tokens() {
                 tokens={tokens}
                 setDeletingTokens={setDeletingTokens}
                 setShowDeleteTokenModal={setShowDeleteTokenModal}
+                tokensVersion={tokensVersion}
               />
             ) : (
               <EmptyState

--- a/ui/src/components/tokens/TokenTable.tsx
+++ b/ui/src/components/tokens/TokenTable.tsx
@@ -79,10 +79,12 @@ type TokenTableProps = {
   tokens: IAuthToken[];
   setDeletingTokens: (tokens: IAuthToken[]) => void;
   setShowDeleteTokenModal: (show: boolean) => void;
+  tokensVersion: number;
 };
 
 export default function TokenTable(props: TokenTableProps) {
-  const { tokens, setDeletingTokens, setShowDeleteTokenModal } = props;
+  const { tokens, setDeletingTokens, setShowDeleteTokenModal, tokensVersion } =
+    props;
   const searchThreshold = 10;
   const [sorting, setSorting] = useState<SortingState>([]);
 
@@ -95,13 +97,9 @@ export default function TokenTable(props: TokenTableProps) {
     setShowDeleteTokenModal(true);
   };
 
-  const handleTokenDeletedEvent = () => setRowSelection({});
-
   useEffect(() => {
-    window.addEventListener('token-deleted', handleTokenDeletedEvent);
-    return () =>
-      window.removeEventListener('token-deleted', handleTokenDeletedEvent);
-  }, []);
+    setRowSelection({});
+  }, [tokensVersion]);
 
   const columns = [
     columnHelper.display({


### PR DESCRIPTION
another way of triggering refresh of selected rows without using events