### PR TITLE
feat(wip): support specific auth method validation

### DIFF
--- a/internal/config/authentication.go
+++ b/internal/config/authentication.go
@@ -133,9 +133,7 @@ func (c *AuthenticationConfig) SessionEnabled() bool {
 }
 
 func (c *AuthenticationConfig) validate() error {
-	var (
-		sessionEnabled bool
-	)
+	var sessionEnabled bool
 
 	for _, info := range c.Methods.AllMethods() {
 		sessionEnabled = sessionEnabled || (info.Enabled && info.SessionCompatible)

--- a/internal/config/authentication.go
+++ b/internal/config/authentication.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"net/url"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -477,14 +478,9 @@ func (a AuthenticationMethodGithubConfig) info() AuthenticationMethodInfo {
 
 func (a AuthenticationMethodGithubConfig) validate() error {
 	// ensure scopes contain read:org if allowed organizations is not empty
-	if len(a.AllowedOrganizations) > 0 {
-		for _, scope := range a.Scopes {
-			if scope == "read:org" {
-				return nil
-			}
-		}
-
+	if len(a.AllowedOrganizations) > 0 && !slices.Contains(a.Scopes, "read:org") {
 		return fmt.Errorf("scopes must contain read:org when allowed_organizations is not empty")
 	}
+
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -446,6 +446,11 @@ func TestLoad(t *testing.T) {
 			},
 		},
 		{
+			name:    "authentication github requires read:org scope when allowing orgs",
+			path:    "./testdata/authentication/github_no_org_scope.yml",
+			wantErr: errors.New("scopes must contain read:org when allowed_organizations is not empty"),
+		},
+		{
 			name: "advanced",
 			path: "./testdata/advanced.yml",
 			expected: func() *Config {

--- a/internal/config/testdata/authentication/github_no_org_scope.yml
+++ b/internal/config/testdata/authentication/github_no_org_scope.yml
@@ -1,0 +1,12 @@
+authentication:
+  required: true
+  session:
+    domain: "http://localhost:8080"
+    secure: false
+  methods:
+    github:
+      enabled: true
+      scopes:
+        - "user:email"
+      allowed_organizations:
+        - "github.com/flipt-io"


### PR DESCRIPTION
@erka , I think this might work to validate that they have the required `read:org` scopes if they have `allowed_organizations` required

re: https://github.com/flipt-io/flipt/pull/2508#issuecomment-1848601570

This is still WIP as I need to add some tests, but wanted to unblock you and get yours and @georgemac 's thoughts