### PR TITLE
chore: unexport and rename some ofrep error funcs

### DIFF
--- a/internal/server/ofrep/errors.go
+++ b/internal/server/ofrep/errors.go
@@ -18,7 +18,7 @@ func statusWithKey(st *status.Status, key string) (*status.Status, error) {
 	})
 }
 
-func NewBadRequestError(key string, err error) error {
+func newBadRequestError(key string, err error) error {
 	v := status.New(codes.InvalidArgument, err.Error())
 	v, derr := statusWithKey(v, key)
 	if derr != nil {
@@ -27,7 +27,7 @@ func NewBadRequestError(key string, err error) error {
 	return v.Err()
 }
 
-func NewFlagNotFoundError(key string) error {
+func newFlagNotFoundError(key string) error {
 	v := status.New(codes.NotFound, fmt.Sprintf("flag was not found %s", key))
 	v, derr := statusWithKey(v, key)
 	if derr != nil {
@@ -36,10 +36,10 @@ func NewFlagNotFoundError(key string) error {
 	return v.Err()
 }
 
-func NewFlagMissing() error {
+func newFlagMissingError() error {
 	return status.Error(codes.InvalidArgument, "flag key was not provided")
 }
 
-func NewFlagsMissing() error {
+func newFlagsMissingError() error {
 	return status.Error(codes.InvalidArgument, "flags were not provided in context")
 }

--- a/internal/server/ofrep/evaluation.go
+++ b/internal/server/ofrep/evaluation.go
@@ -19,7 +19,7 @@ const ofrepCtxTargetingKey = "targetingKey"
 func (s *Server) EvaluateFlag(ctx context.Context, r *ofrep.EvaluateFlagRequest) (*ofrep.EvaluatedFlag, error) {
 	s.logger.Debug("ofrep flag", zap.Stringer("request", r))
 	if r.Key == "" {
-		return nil, NewFlagMissing()
+		return nil, newFlagMissingError()
 	}
 	entityId := getTargetingKey(r.Context)
 	output, err := s.bridge.OFREPFlagEvaluation(ctx, EvaluationBridgeInput{
@@ -47,7 +47,7 @@ func (s *Server) EvaluateBulk(ctx context.Context, r *ofrep.EvaluateBulkRequest)
 	entityId := getTargetingKey(r.Context)
 	flagKeys, ok := r.Context["flags"]
 	if !ok {
-		return nil, NewFlagsMissing()
+		return nil, newFlagsMissingError()
 	}
 	namespaceKey := getNamespace(ctx)
 	keys := strings.Split(flagKeys, ",")
@@ -134,11 +134,11 @@ func transformReason(reason rpcevaluation.EvaluationReason) ofrep.EvaluateReason
 func transformError(key string, err error) error {
 	switch {
 	case flipterrors.AsMatch[flipterrors.ErrInvalid](err):
-		return NewBadRequestError(key, err)
+		return newBadRequestError(key, err)
 	case flipterrors.AsMatch[flipterrors.ErrValidation](err):
-		return NewBadRequestError(key, err)
+		return newBadRequestError(key, err)
 	case flipterrors.AsMatch[flipterrors.ErrNotFound](err):
-		return NewFlagNotFoundError(key)
+		return newFlagNotFoundError(key)
 	}
 	return err
 }

--- a/internal/server/ofrep/evaluation_test.go
+++ b/internal/server/ofrep/evaluation_test.go
@@ -113,25 +113,25 @@ func TestEvaluateFlag_Failure(t *testing.T) {
 		{
 			name:        "should return a targeting key missing error when a key is not provided",
 			req:         &ofrep.EvaluateFlagRequest{},
-			expectedErr: NewFlagMissing(),
+			expectedErr: newFlagMissingError(),
 		},
 		{
 			name:        "should return a bad request error when an invalid is returned by the bridge",
 			req:         &ofrep.EvaluateFlagRequest{Key: "test-flag"},
 			err:         flipterrors.ErrInvalid("invalid"),
-			expectedErr: NewBadRequestError("test-flag", flipterrors.ErrInvalid("invalid")),
+			expectedErr: newBadRequestError("test-flag", flipterrors.ErrInvalid("invalid")),
 		},
 		{
 			name:        "should return a bad request error when a validation error is returned by the bridge",
 			req:         &ofrep.EvaluateFlagRequest{Key: "test-flag"},
 			err:         flipterrors.InvalidFieldError("field", "reason"),
-			expectedErr: NewBadRequestError("test-flag", flipterrors.InvalidFieldError("field", "reason")),
+			expectedErr: newBadRequestError("test-flag", flipterrors.InvalidFieldError("field", "reason")),
 		},
 		{
 			name:        "should return a not found error when a flag not found error is returned by the bridge",
 			req:         &ofrep.EvaluateFlagRequest{Key: "test-flag"},
 			err:         flipterrors.ErrNotFound("test-flag"),
-			expectedErr: NewFlagNotFoundError("test-flag"),
+			expectedErr: newFlagNotFoundError("test-flag"),
 		},
 		{
 			name:        "should return a general error",

--- a/internal/server/ofrep/middleware_test.go
+++ b/internal/server/ofrep/middleware_test.go
@@ -23,22 +23,22 @@ func TestErrorHandler(t *testing.T) {
 		expectedOutput string
 	}{
 		{
-			input:          NewFlagsMissing(),
+			input:          newFlagsMissingError(),
 			expectedCode:   http.StatusBadRequest,
 			expectedOutput: `{"errorCode":"INVALID_CONTEXT","errorDetails":"flags were not provided in context"}`,
 		},
 		{
-			input:          NewFlagMissing(),
+			input:          newFlagMissingError(),
 			expectedCode:   http.StatusBadRequest,
 			expectedOutput: `{"errorCode":"INVALID_CONTEXT","errorDetails":"flag key was not provided"}`,
 		},
 		{
-			input:          NewFlagNotFoundError("flag1"),
+			input:          newFlagNotFoundError("flag1"),
 			expectedCode:   http.StatusNotFound,
 			expectedOutput: `{"key":"flag1","errorCode":"FLAG_NOT_FOUND","errorDetails":"flag was not found flag1"}`,
 		},
 		{
-			input:          NewBadRequestError("flag1", errors.New("custom failure")),
+			input:          newBadRequestError("flag1", errors.New("custom failure")),
 			expectedCode:   http.StatusBadRequest,
 			expectedOutput: `{"key":"flag1","errorCode":"INVALID_CONTEXT","errorDetails":"custom failure"}`,
 		},


### PR DESCRIPTION
minor change to use unexported funcs for error creators